### PR TITLE
Paging update to follow new API behaviour and work around an API bug

### DIFF
--- a/pycomicvine/__init__.py
+++ b/pycomicvine/__init__.py
@@ -330,6 +330,12 @@ class _SingularResource(_Resource):
 class _ListResource(_Resource):
     def _request_object(self, **params):
         type(self)._ensure_resource_url()
+        if 'offset' in params:
+            limit = params['limit'] or self._limit
+            params['page'] = params['offset']/params['limit'] + 1
+            del params['offset']
+        elif 'page' not in params:
+            params['page'] = 1
         return type(self)._request(type(self)._resource_url, **params)
 
     def __init__(self, init_list = None, **kwargs):
@@ -376,13 +382,13 @@ class _ListResource(_Resource):
                         offset=i,
                         **self._args
                     )
-                for j in range(
-                        len(self._results),
-                        i+response.number_of_page_results
-                    ):
-                    self._results.append(None)
-                for j in range(i, i+response.number_of_page_results):
-                    self._results[j] = response.results[j-i]                   
+                end_result = response.offset + response.number_of_page_results
+                if len(self._results) < end_result:
+                    self._results.extend(
+                        [None] * (end_result - len(self._results)))
+                for j in range(response.offset, 
+                               response.offset+len(response.results)):
+                        self._results[j] = response.results[j-response.offset]
         if type(self._results[index]) == list:
             if type(index) != slice and len(self._results[index]) == 0:
                 self._results[index] = None


### PR DESCRIPTION
The comicvine API now ignores the offset in a request, and instead uses the page parameter for large result sets.  The current pycomicvine behaviour results in large numbers of duplicate results, as well as missing results.

This proposed code does two things - it adds the page parameter to the request, in order to get the additional results as expected, it also includes code to work around a bug in the API.  Sometimes you will ask for 100 results, but only get 99.  I tried a couple of approaches to this, but in the end just settled on returning None for missing entries.  I played with a couple of other ideas for handling this, but this seemed easiest.

As examples of this in practice, when I use the code from HEAD to get a list of volumes containing "Batman" I get 742 results.  When I de-duplicate these I am only left with 100.  With the new code I get 742 unique results:

rgh@eduardo ~/git/pycomicvine $ python volumelist.py batman | sort -u | wc -l
100

rgh@eduardo ~/git/mycomicvine $ python volumelist.py batman | sort -u | wc -l
742

With a similar query for "Spider-man" (which shows the buggy behaviour described above) there is a similar discrepancy with the results.  The search reports 632 issues, yet it can be seen that there are 100 unique results from the code at HEAD, and 630 from the revised code. 

rgh@eduardo ~/git/pycomicvine $ python volumelist.py spider-man | sort -u | wc -l
100

rgh@eduardo ~/git/mycomicvine $ python volumelist.py spider-man | sort -u | wc -l
630

This patch works well for my calibre plugin, hopefully this will be useful for the base library too...
