### PR TITLE
Fix a NameError in _SingularResource.__init__

### DIFF
--- a/pycomicvine/__init__.py
+++ b/pycomicvine/__init__.py
@@ -237,7 +237,7 @@ class _SingularResource(_Resource):
             except KeyError:
                 raise pycomicvine.error.InvalidResourceError(
                         "Resource type '{0!s}' does not exist.".format(
-                                resource_type
+                                type(self)
                             )
                     )
             self._detail_url = type(self)._resource_url + \


### PR DESCRIPTION
Fix the exception raised in _SingularResource.__init__ so that the 
message matches the key used.

resource_type raises a NameError here as it is not present in the scope
of the **init** method.
