### PR TITLE
Handle missing resources more gracefully.

### DIFF
--- a/pycomicvine/__init__.py
+++ b/pycomicvine/__init__.py
@@ -910,8 +910,8 @@ class Types(_ListResource):
                 type['singular_resource_class'] = getattr(
                         sys.modules[__name__],
                         Types._camilify_type_name(
-                                type['detail_resource_name']
-                            )
+                                type['detail_resource_name']),
+                        UnknownResource
                     )
                 self._mapping[type['detail_resource_name']] = type
                 self._mapping[type['list_resource_name']] = type
@@ -943,6 +943,9 @@ class Types(_ListResource):
             else:
                 camel_string += c
         return camel_string
+
+class UnknownResource(_Resource):
+    pass
 
 class Video(_SingularResource):
     api_detail_url = AttributeDefinition('keep')


### PR DESCRIPTION
Currently if any comicvine resource type is not modelled then the Types
class will raise an exception.

Add  a default UnknownResource class, and map resources to this by default so that the module is not broken when Comicvine add new resources.
